### PR TITLE
Added missing backslash to filepath

### DIFF
--- a/log4j.properties
+++ b/log4j.properties
@@ -17,7 +17,7 @@ log4j.appender.dest2.layout.ConversionPattern=[%d{HH:mm:ss}] %-5p %C{1} - %m%n
 
 # R is the RollingFileAppender that outputs to a rolling log
 log4j.appender.R=org.apache.log4j.RollingFileAppender
-log4j.appender.R.File=${java.home}log4j_jgap_lf.log
+log4j.appender.R.File=${java.home}\\log4j_jgap_lf.log
 log4j.appender.R.MaxFileSize=500KB
 
 # Configure a pattern layout, the size of the file and the


### PR DESCRIPTION
Hello! I was using the JGAP framework and I came across some problems when the logger was attempting to create a .log file in my Java directory. I noticed that in the error message the path was missing a backslash. Adding the backslash to the log4j.properties file seemed to fix the problem.